### PR TITLE
no age shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "description": "Records the current tab in an offscreen document.",
     "version": "1",
     "manifest_version": 3,
-    "minimum_chrome_version": "116",
+    "minimum_chrome_version": "1",
     "action": {
       "default_icon": "icons/not-recording.png"
     },


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)